### PR TITLE
Add pass-the-sha1 for non domain joined machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ SharpDPAPI is licensed under the BSD 3-Clause license.
             /pvk:key.pvk            -   use a DPAPI domain private key file to first decrypt reachable user masterkeys
             /password:X             -   first decrypt the current user's masterkeys using a plaintext password or NTLM hash (works remotely)
             /server:SERVER          -   triage a remote server, assuming admin access
+            /local                  -   machine is non domain-joined. Keys use SHA1 instead of NTLM. Password may be supplied in plaintext or as a SHA1 hash
 
 
         Arguments for the credentials|vaults|rdg|keepass|triage|blob|ps commands:

--- a/SharpChrome/SharpChrome.csproj
+++ b/SharpChrome/SharpChrome.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharpChrome</RootNamespace>
     <AssemblyName>SharpChrome</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SharpChrome/app.config
+++ b/SharpChrome/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/SharpDPAPI/Commands/Blob.cs
+++ b/SharpDPAPI/Commands/Blob.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SharpDPAPI.Commands
 {
@@ -63,7 +64,11 @@ namespace SharpDPAPI.Commands
             else if (arguments.ContainsKey("/password"))
             {
                 string password = arguments["/password"];
-                Console.WriteLine("[*] Will decrypt user masterkeys with password: {0}\r\n", password);
+                
+                Console.WriteLine("[*] Will decrypt user masterkeys with {0}: {1}\r\n",
+                    Regex.IsMatch(password, @"^([a-f0-9]{32}|[a-f0-9]{40})$", RegexOptions.IgnoreCase)
+                        ? "hash" : "password", password);
+
                 if (arguments.ContainsKey("/server"))
                 {
                     masterkeys = Triage.TriageUserMasterKeys(null, true, arguments["/server"], password);

--- a/SharpDPAPI/Commands/Credentials.cs
+++ b/SharpDPAPI/Commands/Credentials.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace SharpDPAPI.Commands
 {
@@ -44,7 +45,11 @@ namespace SharpDPAPI.Commands
             else if (arguments.ContainsKey("/password"))
             {
                 string password = arguments["/password"];
-                Console.WriteLine("[*] Will decrypt user masterkeys with password: {0}\r\n", password);
+
+                Console.WriteLine("[*] Will decrypt user masterkeys with {0}: {1}\r\n", 
+                    Regex.IsMatch(password, @"^([a-f0-9]{32}|[a-f0-9]{40})$", RegexOptions.IgnoreCase)
+                        ? "hash" : "password", password);
+
                 if (arguments.ContainsKey("/server"))
                 {
                     masterkeys = Triage.TriageUserMasterKeys(null, true, arguments["/server"], password);

--- a/SharpDPAPI/Commands/Masterkeys.cs
+++ b/SharpDPAPI/Commands/Masterkeys.cs
@@ -55,12 +55,13 @@ namespace SharpDPAPI.Commands
                 {
                     if (!arguments.ContainsKey("/sid"))
                     {
-                        Console.WriteLine("[X] When using /password:X with /target:X, a /sid:X (domain user SID) is required!");
+                        Console.WriteLine("[X] When using /password:X with /target:X, a /sid:X (user SID) is required!");
                         return;
                     }
                     else {
                         Console.WriteLine("[*] Triaging masterkey target: {0}\r\n", arguments["/target"]);
-                        mappings = Triage.TriageUserMasterKeys(null, true, "", password, arguments["/target"], arguments["/sid"]);
+                        mappings = Triage.TriageUserMasterKeys(null, true, "", password, arguments["/target"], 
+                            arguments["/sid"], false, arguments.ContainsKey("/local"));
                     }
                 }
                 else
@@ -79,7 +80,7 @@ namespace SharpDPAPI.Commands
                 {
                     if (!arguments.ContainsKey("/sid"))
                     {
-                        Console.WriteLine("[X] When dumping hashes with /target:X, a /sid:X (domain user SID) is required!");
+                        Console.WriteLine("[X] When dumping hashes with /target:X, a /sid:X (user SID) is required!");
                         return;
                     }
                     else

--- a/SharpDPAPI/Commands/Masterkeys.cs
+++ b/SharpDPAPI/Commands/Masterkeys.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace SharpDPAPI.Commands
 {
@@ -46,7 +47,11 @@ namespace SharpDPAPI.Commands
             else if (arguments.ContainsKey("/password"))
             {
                 password = arguments["/password"];
-                Console.WriteLine("[*] Will decrypt user masterkeys with password: {0}\r\n", password);
+                
+                Console.WriteLine("[*] Will decrypt user masterkeys with {0}: {1}\r\n", 
+                    Regex.IsMatch(password, @"^([a-f0-9]{32}|[a-f0-9]{40})$", RegexOptions.IgnoreCase)
+                        ? "hash" : "password", password);
+                
                 if (arguments.ContainsKey("/server"))
                 {
                     mappings = Triage.TriageUserMasterKeys(null, true, arguments["/server"], password);

--- a/SharpDPAPI/Commands/Protect.cs
+++ b/SharpDPAPI/Commands/Protect.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static SharpDPAPI.Crypto;
+
+namespace SharpDPAPI.Commands
+{
+    public class Protect : ICommand
+    {
+        public static string CommandName => "protect";
+
+        public void Execute(Dictionary<string, string> arguments)
+        {
+            Console.WriteLine("\r\n[*] Action: Encrypt DPAPI blob");
+
+            if (!arguments.ContainsKey("/mkfile"))
+            {
+                Console.WriteLine("[!] Error: Provide a master key file using /mkfile:<path>");
+                return;
+            }
+
+            if (!arguments.ContainsKey("/password"))
+            {
+                Console.WriteLine("[!] Error: Provide a password");
+                return;
+            }
+
+            if (!arguments.ContainsKey("/input"))
+            {
+                Console.WriteLine("[!] Error: provide an input file path or base64 using /input:<file>");
+                return;
+            }
+
+            if (!arguments.ContainsKey("/output"))
+            {
+                Console.WriteLine("[!] Error: provide an output file path using /output:<file>");
+                return;
+            }
+
+            byte[] plainBytes;
+            string inputFile = arguments["/input"].Trim('"').Trim('\'');
+            string outputFile = arguments["/output"].Trim('"').Trim('\'');
+            string masterKeyFile = arguments["/mkfile"].Trim('"').Trim('\'');
+            string password = arguments["/password"];
+
+            if (File.Exists(inputFile))
+            {
+                plainBytes = File.ReadAllBytes(inputFile);
+            }
+            else
+            {
+                plainBytes = Convert.FromBase64String(inputFile);
+            }
+
+            Console.WriteLine("[*] Using masterkey: {0}", masterKeyFile);
+            
+            string userSID = Dpapi.ExtractSidFromPath(masterKeyFile);
+            
+            var masterkeys = Triage.TriageUserMasterKeys(
+                null, password: password, target: masterKeyFile,
+                local: true, userSID: userSID
+                );
+            
+            if (masterkeys.Count != 1)
+            {
+                Console.WriteLine("[!] Failed to decrypt masterkey. Wrong password?");
+                return;
+            }
+
+            var masterKey = masterkeys.First();
+            byte[] enc = Dpapi.CreateDPAPIBlob(plainBytes, Helpers.StringToByteArray(masterKey.Value),
+                EncryptionAlgorithm.CALG_AES_256,
+                HashAlgorithm.CALG_SHA_512,
+                new Guid(masterKey.Key));
+
+            File.WriteAllBytes(outputFile, enc);
+            Console.WriteLine("[+] Done! Wrote {0} bytes to: {1}", enc.Length, outputFile);
+        }
+    }
+}

--- a/SharpDPAPI/Commands/Protect.cs
+++ b/SharpDPAPI/Commands/Protect.cs
@@ -39,10 +39,20 @@ namespace SharpDPAPI.Commands
             }
 
             byte[] plainBytes;
+            byte[] entropy = null;
+
             string inputFile = arguments["/input"].Trim('"').Trim('\'');
             string outputFile = arguments["/output"].Trim('"').Trim('\'');
+            string sid = arguments.ContainsKey("/sid") ? arguments["/sid"] : string.Empty;
             string masterKeyFile = arguments["/mkfile"].Trim('"').Trim('\'');
             string password = arguments["/password"];
+            bool isLocalMachine = arguments.ContainsKey("/local");
+            string description = arguments.ContainsKey("/description") ? arguments["/description"] : string.Empty;
+
+            if (arguments.ContainsKey("/entropy"))
+            {
+                entropy = Helpers.StringToByteArray(arguments["/entropy"]);
+            }
 
             if (File.Exists(inputFile))
             {
@@ -54,28 +64,56 @@ namespace SharpDPAPI.Commands
             }
 
             Console.WriteLine("[*] Using masterkey: {0}", masterKeyFile);
+
+            string userSID = string.Empty;
+            Dictionary<string, string> keyDict;
+            KeyValuePair<string, string> keyPair = default;
             
-            string userSID = Dpapi.ExtractSidFromPath(masterKeyFile);
-            
-            var masterkeys = Triage.TriageUserMasterKeys(
-                null, password: password, target: masterKeyFile,
-                local: true, userSID: userSID
-                );
-            
-            if (masterkeys.Count != 1)
+            byte[] masterKeyBytes = null;
+            Guid masterKeyGuid = default;
+
+            try
+            {
+                if (!isLocalMachine)
+                {
+                    userSID = string.IsNullOrEmpty(sid) ? sid : Dpapi.ExtractSidFromPath(masterKeyFile);
+                    keyDict = Triage.TriageUserMasterKeys(null, password: password, target: masterKeyFile, local: true, userSID: userSID);
+                    if (keyDict.Count == 1)
+                    {
+                        keyPair = keyDict.First();
+                        masterKeyBytes = Helpers.StringToByteArray(keyPair.Value);
+                        masterKeyGuid = new Guid(keyPair.Key);
+                    }
+                }
+                else
+                {
+                    keyPair = Dpapi.DecryptMasterKeyWithSha(File.ReadAllBytes(masterKeyFile), Helpers.StringToByteArray(password));
+                    masterKeyBytes = Helpers.StringToByteArray(keyPair.Value);
+                    masterKeyGuid = new Guid(keyPair.Key);
+                }
+            }
+            catch
+            {
+            }
+
+            if (masterKeyBytes == null || masterKeyGuid == null)
             {
                 Console.WriteLine("[!] Failed to decrypt masterkey. Wrong password?");
                 return;
             }
 
-            var masterKey = masterkeys.First();
-            byte[] enc = Dpapi.CreateDPAPIBlob(plainBytes, Helpers.StringToByteArray(masterKey.Value),
+            byte[] enc = Dpapi.CreateDPAPIBlob(plainBytes, masterKeyBytes,
                 EncryptionAlgorithm.CALG_AES_256,
                 HashAlgorithm.CALG_SHA_512,
-                new Guid(masterKey.Key));
+                masterKeyGuid,
+                isLocalMachine: isLocalMachine,
+                entropy: entropy,
+                description: description
+                );
 
             File.WriteAllBytes(outputFile, enc);
             Console.WriteLine("[+] Done! Wrote {0} bytes to: {1}", enc.Length, outputFile);
+            Console.WriteLine("[*] {0}", Convert.ToBase64String(enc));
         }
     }
 }

--- a/SharpDPAPI/Domain/CommandCollection.cs
+++ b/SharpDPAPI/Domain/CommandCollection.cs
@@ -33,6 +33,7 @@ namespace SharpDPAPI.Domain
             _availableCommands.Add(Certificate.CommandName, () => new Certificate());
             _availableCommands.Add(Search.CommandName, () => new Search());
             _availableCommands.Add(SCCM.CommandName, () => new SCCM());
+            _availableCommands.Add(Protect.CommandName, () => new Protect());
         }
 
         public bool ExecuteCommand(string commandName, Dictionary<string, string> arguments)

--- a/SharpDPAPI/Domain/Info.cs
+++ b/SharpDPAPI/Domain/Info.cs
@@ -45,7 +45,7 @@ User Triage:
         /target:FILE/folder     -   triage a specific masterkey, or a folder full of masterkeys (otherwise triage local masterkeys)
         /pvk:BASE64...          -   use a base64'ed DPAPI domain private key file to first decrypt reachable user masterkeys
         /pvk:key.pvk            -   use a DPAPI domain private key file to first decrypt reachable user masterkeys
-        /password:X             -   first decrypt the current user's masterkeys using a plaintext password (works remotely)
+        /password:X             -   first decrypt the current user's masterkeys using a plaintext password or hash (works remotely)
         /server:SERVER          -   triage a remote server, assuming admin access
 
 
@@ -53,7 +53,7 @@ User Triage:
 
         Decryption:
             /unprotect          -   force use of CryptUnprotectData() for 'ps', 'rdg', or 'blob' commands
-            /password:X         -   first decrypt the current user's masterkeys using a plaintext password. Works with any function, as well as remotely.
+            /password:X         -   first decrypt the current user's masterkeys using a plaintext password or hash. Works with any function, as well as remotely.
             GUID1:SHA1 ...      -   use a one or more GUID:SHA1 masterkeys for decryption
             /mkfile:FILE        -   use a file of one or more GUID:SHA1 masterkeys for decryption
             /pvk:BASE64...      -   use a base64'ed DPAPI domain private key file to first decrypt reachable user masterkeys

--- a/SharpDPAPI/Domain/Info.cs
+++ b/SharpDPAPI/Domain/Info.cs
@@ -73,7 +73,15 @@ Certificate Triage:
         /machine                                        -   use the local machine store for certificate triage
         /mkfile | /target                               -   for /machine triage
         /pvk | /mkfile | /password | /server | /target  -   for user triage
-    
+
+
+Encryption:
+    Arguments for the 'protect' command:
+        /input                                          -   the input file or base64 encoded string you want to protect using DPAPI
+        /output                                         -   the output file the encrypted blob will be written to
+        /mkfile                                         -   the path to the masterkey file to use for encryption 
+        /password                                       -   the password, or password hash (SHA1 or NTLM) to decrypt the masterkey file
+
 
 Note: in most cases, just use *triage* if you're targeting user DPAPI secrets and *machinetriage* if you're going after SYSTEM DPAPI secrets.
       These functions wrap all the other applicable functions that can be automatically run.

--- a/SharpDPAPI/Domain/Info.cs
+++ b/SharpDPAPI/Domain/Info.cs
@@ -81,6 +81,8 @@ Encryption:
         /output                                         -   the output file the encrypted blob will be written to
         /mkfile                                         -   the path to the masterkey file to use for encryption 
         /password                                       -   the password, or password hash (SHA1 or NTLM) to decrypt the masterkey file
+        /local                                          -   encrypt the data with the local machine context instead of the user (requires SYSTEM DPAPI key)
+        /sid                                            -   provide the SID to use for decrypting the masterkey (by default this is guessed from the path)
 
 
 Note: in most cases, just use *triage* if you're targeting user DPAPI secrets and *machinetriage* if you're going after SYSTEM DPAPI secrets.

--- a/SharpDPAPI/SharpDPAPI.csproj
+++ b/SharpDPAPI/SharpDPAPI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharpDPAPI</RootNamespace>
     <AssemblyName>SharpDPAPI</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -72,6 +72,7 @@
     <Compile Include="Commands\Machinemasterkeys.cs" />
     <Compile Include="Commands\Machinetriage.cs" />
     <Compile Include="Commands\Machinevaults.cs" />
+    <Compile Include="Commands\Protect.cs" />
     <Compile Include="Commands\SCCM.cs" />
     <Compile Include="Commands\Search.cs" />
     <Compile Include="Commands\PS.cs" />

--- a/SharpDPAPI/app.config
+++ b/SharpDPAPI/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/SharpDPAPI/lib/Dpapi.cs
+++ b/SharpDPAPI/lib/Dpapi.cs
@@ -854,10 +854,13 @@ namespace SharpDPAPI
         }
 
         public static byte[] CreateDPAPIBlob(byte[] plaintext, byte[] masterKey, EncryptionAlgorithm algCrypt, 
-            HashAlgorithm algHash, Guid masterKeyGuid, byte[] entropy = null, string description = "")
+            HashAlgorithm algHash, Guid masterKeyGuid, byte[] entropy = null, string description = "", bool isLocalMachine = false)
         {
             var descBytes = string.IsNullOrEmpty(description) ? 
                 new byte[2] : Encoding.Unicode.GetBytes(description);
+
+            var flags = 0;
+            flags |= isLocalMachine ? 0x4 : 0; // CRYPTPROTECT_LOCAL_MACHINE
 
             var saltBytes = GetRandomBytes(32); // Default salt length (TODO: check)
             var hmacKeyLen = 0; // Default HMAC key length (TODO: check)
@@ -950,7 +953,6 @@ namespace SharpDPAPI
             offset += 16;
 
             // Flags
-            var flags = 0;
             Array.Copy(BitConverter.GetBytes(flags), 0, blobBytes, offset, 4);
             offset += 4;
 

--- a/SharpDPAPI/lib/Helpers.cs
+++ b/SharpDPAPI/lib/Helpers.cs
@@ -13,6 +13,13 @@ namespace SharpDPAPI
 {
     public static class Helpers
     {
+        public static byte[] SubArray(byte[] data, int index, int length)
+        {
+            byte[] result = new byte[length];
+            Array.Copy(data, index, result, 0, length);
+            return result;
+        }
+
         public static void EncodeLength(BinaryWriter stream, int length)
         {
             if (length < 0) throw new ArgumentOutOfRangeException("length", "Length must be non-negative");

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -21,7 +21,7 @@ namespace SharpDPAPI
             if (!String.IsNullOrEmpty(target))
             {
                 // if we're targeting specific masterkey files
-                if (((backupKeyBytes == null) || (backupKeyBytes.Length == 0)) && String.IsNullOrEmpty(userSID))
+                if (((backupKeyBytes == null) || (backupKeyBytes.Length == 0)) && String.IsNullOrEmpty(password))
                 {
                     // currently only backupkey is supported
                     Console.WriteLine("[X] The masterkey '/target:X' option currently requires '/pvk:BASE64...' or '/password:X'");

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -58,7 +58,7 @@ namespace SharpDPAPI
                                 }
                                 else if (!String.IsNullOrEmpty(password) && !String.IsNullOrEmpty(userSID))
                                 {
-                                    byte[] hmacBytes = Dpapi.CalculateKeys(password, "", true, userSID);
+                                    byte[] hmacBytes = Dpapi.CalculateKeys(password, "", !local, userSID);
                                     plaintextMasterKey = Dpapi.DecryptMasterKeyWithSha(masterKeyBytes, hmacBytes);
                                 }
                                 else if (dumpHash)

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -11,10 +11,9 @@ namespace SharpDPAPI
     public class Triage
     {
         public static Dictionary<string, string> TriageUserMasterKeys(byte[] backupKeyBytes, bool show = false, string computerName = "", 
-            string password = "", string target = "", string userSID = "", bool dumpHash = false)
+            string password = "", string target = "", string userSID = "", bool dumpHash = false, bool local = false)
         {
             // triage all *user* masterkeys we can find, decrypting if the backupkey is supplied
-            
             var mappings = new Dictionary<string, string>();
             var preferred = new Dictionary<string, string>();
             var canAccess = false;
@@ -90,7 +89,7 @@ namespace SharpDPAPI
                         }
                         else if (!String.IsNullOrEmpty(password))
                         {
-                            byte[] hmacBytes = Dpapi.CalculateKeys(password, "", true, userSID);
+                            byte[] hmacBytes = Dpapi.CalculateKeys(password, "", !local, userSID);
                             plaintextMasterKey = Dpapi.DecryptMasterKeyWithSha(masterKeyBytes, hmacBytes);
                         }
                         else if (dumpHash)


### PR DESCRIPTION
This PR allows the user to specify the `/password` flag in SHA1 format when the machine is not domain-joined (i.e. local). These SHA1 passwords are calculated as `SHA1(UTF16LE(password))`, which is output by mimikatz' `sekurlsa::msv`. This feature mirrors the functionality already provided to support PtH for NTLM on domain-joined machines. 

Note that when using the `masterkeys` command with a `/target` specified (e.g. a path to directory containing masterkeys), SharpDPAPI will not attempt to detect domain-joined-ness via the `BK` file (since it may not exist simply because the user didn't copy it from the target system) - therefore I've also added the `/local` flag which can be specified along with `/target` to force the SHA1 path.
