### PR TITLE
Add Teams statekey support

### DIFF
--- a/SharpChrome/lib/Chrome.cs
+++ b/SharpChrome/lib/Chrome.cs
@@ -363,7 +363,8 @@ namespace SharpChrome
                 {
                     $"{userDirectory}\\AppData\\Local\\Google\\Chrome\\User Data\\Local State",
                     $"{userDirectory}\\AppData\\Local\\Microsoft\\Edge\\User Data\\Local State",
-                    $"{userDirectory}\\AppData\\Local\\BraveSoftware\\Brave-Browser\\User Data\\Local State"
+                    $"{userDirectory}\\AppData\\Local\\BraveSoftware\\Brave-Browser\\User Data\\Local State",
+                    $"{userDirectory}\\AppData\\Roaming\\Microsoft\\Teams\\Local State"
                 };
 
                 foreach(var aesKeyPath in aesKeyPaths)


### PR DESCRIPTION
The current implementation of the statekeys command in SharpChrome does not take into account the target parameter, so it just iterates through known paths. This commit adds quick support for the Microsoft Teams state file.