### PR TITLE
Added unprotect option for user certificates

### DIFF
--- a/SharpDPAPI/Commands/Certificate.cs
+++ b/SharpDPAPI/Commands/Certificate.cs
@@ -17,6 +17,14 @@ namespace SharpDPAPI.Commands
             string server;              // used for remote server specification
             bool cng = false;           // used for CNG certs
             bool showall = false;       // used for CNG certs
+            bool unprotect = false;         // whether to force CryptUnprotectData()
+
+            if (arguments.ContainsKey("/unprotect"))
+            {
+                Console.WriteLine("\r\n[*] Using CryptUnprotectData() for decryption.");
+                unprotect = true;
+            }
+            Console.WriteLine();
 
             // {GUID}:SHA1 keys are the only ones that don't start with /
             Dictionary<string, string> masterkeys = new Dictionary<string, string>();
@@ -143,12 +151,12 @@ namespace SharpDPAPI.Commands
                     if (File.Exists(target))
                     {
                         Console.WriteLine("[*] Target Certificate File: {0}\r\n", target);
-                        Triage.TriageCertFile(target, masterkeys, cng, showall);
+                        Triage.TriageCertFile(target, masterkeys, cng, showall, unprotect);
                     }
                     else if (Directory.Exists(target))
                     {
                         Console.WriteLine("[*] Target Certificate Folder: {0}\r\n", target);
-                        Triage.TriageCertFolder(target, masterkeys, cng, showall);
+                        Triage.TriageCertFolder(target, masterkeys, cng, showall, unprotect);
                     }
                     else
                     {
@@ -157,7 +165,7 @@ namespace SharpDPAPI.Commands
                 }
                 else
                 {
-                    Triage.TriageUserCerts(masterkeys, "", showall);
+                    Triage.TriageUserCerts(masterkeys, "", showall, unprotect);
                 }
             }
 

--- a/SharpDPAPI/Domain/Info.cs
+++ b/SharpDPAPI/Domain/Info.cs
@@ -72,6 +72,7 @@ Certificate Triage:
         /showall                                        -   show all decrypted private key files, not just ones that are linked to installed certs (the default)
         /machine                                        -   use the local machine store for certificate triage
         /mkfile | /target                               -   for /machine triage
+        /unprotect                                      -   force use of CryptUnprotectData() for user triage
         /pvk | /mkfile | /password | /server | /target  -   for user triage
     
 

--- a/SharpDPAPI/lib/Dpapi.cs
+++ b/SharpDPAPI/lib/Dpapi.cs
@@ -15,7 +15,7 @@ namespace SharpDPAPI
 {
     public class Dpapi
     {
-        public static Tuple<string, byte[]> DescribeDPAPICertPrivateKey(string fileName, byte[] dpapiblob, Dictionary<string, string> MasterKeys, byte[] entropy = null)
+        public static Tuple<string, byte[]> DescribeDPAPICertPrivateKey(string fileName, byte[] dpapiblob, Dictionary<string, string> MasterKeys, byte[] entropy = null, bool unprotect = false)
         {
             // decrypts the private key part of a CAPI/CNG blog
 
@@ -83,6 +83,31 @@ namespace SharpDPAPI
             Array.Copy(dpapiblob, offset + 4, signBytes, 0, BitConverter.ToUInt32(dpapiblob, offset));
 
             offset += signBytes.Length + 4;
+
+            if (unprotect)
+            {
+                // use CryptUnprotectData()
+                try
+                {
+                    var decBytes = ProtectedData.Unprotect(dpapiblob, entropy, DataProtectionScope.CurrentUser);
+                    if (decBytes.Length > 0)
+                    {
+                        message += $"\n    Provider GUID    : {strGuidProvider}\n";
+                        message += $"    Master Key GUID  : {strmkguidProvider}\n";
+                        message += $"    Description      : {description}\n";
+                        message += $"    algCrypt         : {(Interop.CryptAlg)algCrypt} (keyLen {algCryptLen})\n";
+                        message += $"    algHash          : {(Interop.CryptAlg)algHash} ({algHash})\n";
+                        message += $"    Salt             : {Helpers.ByteArrayToString(saltBytes)}\n";
+                        message += $"    HMAC             : {Helpers.ByteArrayToString(hmac)}\n";
+                    }
+
+                    return new Tuple<string, byte[]>(message, decBytes);
+                }
+                catch
+                {
+                    Console.WriteLine($"    [!] {fileName} masterkey needed: {strmkguidProvider}");
+                }
+            }
 
             switch (algHash)
             {
@@ -234,7 +259,7 @@ namespace SharpDPAPI
         }
 
 
-        public static Tuple<string, byte[]> DescribeCngCertBlob(string fileName, byte[] blobBytes, Dictionary<string, string> MasterKeys)
+        public static Tuple<string, byte[]> DescribeCngCertBlob(string fileName, byte[] blobBytes, Dictionary<string, string> MasterKeys, bool unprotect = false)
         {
             // Parses a CNG certificate private key blob, decrypting if possible.
 
@@ -274,7 +299,7 @@ namespace SharpDPAPI
             Array.Copy(blobBytes, offset, dpapiblob, 0, dwPrivateKeyLen);
 
             // entropy needed - https://github.com/gentilkiwi/mimikatz/blob/fa42ed93aa4d5aa73825295e2ab757ac96005581/modules/kull_m_key.h#L13
-            Tuple<string, byte[]> result = DescribeDPAPICertPrivateKey(fileName, dpapiblob, MasterKeys, Helpers.Combine(Encoding.UTF8.GetBytes("xT5rZW5qVVbrvpuA"), new byte[1]));
+            Tuple<string, byte[]> result = DescribeDPAPICertPrivateKey(fileName, dpapiblob, MasterKeys, Helpers.Combine(Encoding.UTF8.GetBytes("xT5rZW5qVVbrvpuA"), new byte[1]),unprotect);
 
             string message = result.First;
             if (result.Second.Length > 0)
@@ -286,7 +311,7 @@ namespace SharpDPAPI
         }
 
 
-        public static Tuple<string, byte[]> DescribeCapiCertBlob(string fileName, byte[] blobBytes, Dictionary<string, string> MasterKeys)
+        public static Tuple<string, byte[]> DescribeCapiCertBlob(string fileName, byte[] blobBytes, Dictionary<string, string> MasterKeys, bool unprotect = false)
         {
             // Parses a CAPI certificate private key blob, decrypting if possible.
 
@@ -375,7 +400,7 @@ namespace SharpDPAPI
                     var dpapiblob = new byte[len];
                     Array.Copy(blobBytes, offset, dpapiblob, 0, len);
 
-                    Tuple<string, byte[]> result = DescribeDPAPICertPrivateKey(fileName, dpapiblob, MasterKeys);
+                    Tuple<string, byte[]> result = DescribeDPAPICertPrivateKey(fileName, dpapiblob, MasterKeys, null, unprotect);
                     string message = result.First;
                     if(result.Second.Length > 0)
                     {
@@ -390,18 +415,18 @@ namespace SharpDPAPI
         }
 
 
-        public static ExportedCertificate DescribeCertificate(string fileName, byte[] certificateBytes, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false)
+        public static ExportedCertificate DescribeCertificate(string fileName, byte[] certificateBytes, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false, bool unprotect = false)
         {
             // takes a raw certificate private key blob and decrypts/displays if possible
 
             Tuple<string, byte[]> result = new Tuple<string, byte[]>("", null);
             if (cng)
             {
-                result = DescribeCngCertBlob(fileName, certificateBytes, MasterKeys);
+                result = DescribeCngCertBlob(fileName, certificateBytes, MasterKeys, unprotect);
             }
             else
             {
-                result = DescribeCapiCertBlob(fileName, certificateBytes, MasterKeys);
+                result = DescribeCapiCertBlob(fileName, certificateBytes, MasterKeys, unprotect);
             }
 
             string statusMessage = result.First;

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -626,7 +626,7 @@ namespace SharpDPAPI
             Console.WriteLine();
         }
 
-        public static void TriageCertFile(string certFilePath, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false)
+        public static void TriageCertFile(string certFilePath, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false, bool unprotect = false)
         {
             // triage a certificate file
 
@@ -635,7 +635,7 @@ namespace SharpDPAPI
 
             try
             {
-                ExportedCertificate cert = Dpapi.DescribeCertificate(fileName, certificateBytes, MasterKeys, cng, alwaysShow);
+                ExportedCertificate cert = Dpapi.DescribeCertificate(fileName, certificateBytes, MasterKeys, cng, alwaysShow, unprotect);
 
                 if (cert.Thumbprint != "")
                 {
@@ -673,7 +673,7 @@ namespace SharpDPAPI
             }
         }
 
-        public static void TriageCertFolder(string folder, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false)
+        public static void TriageCertFolder(string folder, Dictionary<string, string> MasterKeys, bool cng = false, bool alwaysShow = false, bool unprotect = false)
         {
             // triage a specific certificate folder
             if (!Directory.Exists(folder))
@@ -690,7 +690,7 @@ namespace SharpDPAPI
                         @"[0-9A-Fa-f]{32}[_][0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}")
                     )
                     {
-                        TriageCertFile(file, MasterKeys, cng, alwaysShow);
+                        TriageCertFile(file, MasterKeys, cng, alwaysShow, unprotect);
                     }
                 }
             }
@@ -734,7 +734,7 @@ namespace SharpDPAPI
             }
         }
 
-        public static void TriageUserCerts(Dictionary<string, string> MasterKeys, string computerName = "", bool showall = false)
+        public static void TriageUserCerts(Dictionary<string, string> MasterKeys, string computerName = "", bool showall = false, bool unprotect = false)
         {
             string[] userDirs;
             if (!String.IsNullOrEmpty(computerName))
@@ -778,7 +778,7 @@ namespace SharpDPAPI
 
                 foreach (var directory in directories)
                 {
-                    TriageCertFolder(directory, MasterKeys, false, showall);
+                    TriageCertFolder(directory, MasterKeys, false, showall, unprotect);
                 }
 
                 var userCngKeysPath = $"{dir}\\AppData\\Roaming\\Microsoft\\Crypto\\Keys\\";
@@ -786,7 +786,7 @@ namespace SharpDPAPI
                 if (!Directory.Exists(userCngKeysPath))
                     continue;
 
-                TriageCertFolder(userCngKeysPath, MasterKeys, true, showall);
+                TriageCertFolder(userCngKeysPath, MasterKeys, true, showall, unprotect);
             }
         }
 


### PR DESCRIPTION
- Added extra flag `/unprotect` for `certificates` command.
- Updated README to reflect these changes.

It uses `CryptUnprotectData` just like the other commands to decrypt the private keys of both CryptoAPI and CNG certificates without any other requirements as long as you run the tool in the context of the user whose certificates you want to export.