### PR TITLE
SameSite, Secure, HttpOnly, and EditThisCookie Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vs
 *.user
 [Dd]ebug/


### PR DESCRIPTION
This PR is meant to lightly modify current behavior. Before some cookie attributes were hard-coded leading to unexpected behavior. These changes ensure the miscellaneous cookie attributes of SameSite, Secure, and HttpOnly are queried and displayed to the user when asking for JSON format. Additionally, the format of EditThisCookie has been updated, and thus some attributes in the JSON dump (such as `storeId`) have been updated to reflect those changes.