### PR TITLE
Swapped Managed API usage for their CryptoServiceProvider alternatives

### DIFF
--- a/SharpChrome/SQLite/csharp-sqlite-src/crypto.cs
+++ b/SharpChrome/SQLite/csharp-sqlite-src/crypto.cs
@@ -163,9 +163,9 @@ static void CODEC_TRACE( string T, params object[] ap ) { if ( sqlite3PagerTrace
     const int CIPHER_ENCRYPT = 1;        //#define CIPHER_ENCRYPT 1
 
 #if NET_2_0
-    static RijndaelManaged Aes = new RijndaelManaged();
+    static RijndaelCryptoServiceProvider Aes = new RijndaelCryptoServiceProvider();
 #else
-    static AesManaged Aes = new AesManaged();
+    static AesCryptoServiceProvider Aes = new AesCryptoServiceProvider();
 #endif
 
     /* BEGIN CRYPTO */

--- a/SharpDPAPI/lib/Crypto.cs
+++ b/SharpDPAPI/lib/Crypto.cs
@@ -74,7 +74,7 @@ namespace SharpDPAPI
                 case 26128: // 26128 == CALG_AES_256
                 {
                     // takes a byte array of ciphertext bytes and a key array, decrypt the blob with AES256
-                    var aesCryptoProvider = new AesManaged();
+                    var aesCryptoProvider = new AesCryptoServiceProvider();
 
                     var ivBytes = new byte[16];
 
@@ -139,7 +139,7 @@ namespace SharpDPAPI
 
                 byte[] bufferI = Helpers.Combine(ipad, saltBytes);
                 
-                using (var sha1 = new SHA1Managed())
+                using (var sha1 = new SHA1CryptoServiceProvider())
                 {
                     var sha1BufferI = sha1.ComputeHash(bufferI);
                     
@@ -182,7 +182,7 @@ namespace SharpDPAPI
 
             if (algHash == 32772)
             {
-                using (var sha1 = new SHA1Managed())
+                using (var sha1 = new SHA1CryptoServiceProvider())
                 {
                     var ipadSHA1bytes = sha1.ComputeHash(ipad);
                     var ppadSHA1bytes = sha1.ComputeHash(opad);
@@ -250,7 +250,7 @@ namespace SharpDPAPI
         {
             // helper to AES decrypt a given blob with optional IV
 
-            var aesCryptoProvider = new AesManaged();
+            var aesCryptoProvider = new AesCryptoServiceProvider();
 
             aesCryptoProvider.Key = key;
             if (IV.Length != 0)
@@ -266,7 +266,7 @@ namespace SharpDPAPI
 
         public static byte[] LSAAESDecrypt(byte[] key, byte[] data)
         {
-            var aesCryptoProvider = new AesManaged();
+            var aesCryptoProvider = new AesCryptoServiceProvider();
             
             aesCryptoProvider.Key = key;
             aesCryptoProvider.IV = new byte[16];

--- a/SharpDPAPI/lib/Dpapi.cs
+++ b/SharpDPAPI/lib/Dpapi.cs
@@ -1753,7 +1753,7 @@ namespace SharpDPAPI
             if (!domain)
             {
                 //Calculate SHA1 from user password
-                using (var sha1 = new SHA1Managed())
+                using (var sha1 = new SHA1CryptoServiceProvider())
                 {
                     sha1bytes_password = sha1.ComputeHash(utf16pass);
                 }
@@ -1848,7 +1848,7 @@ namespace SharpDPAPI
             var masterKey = new byte[masterKeyLen];
             Buffer.BlockCopy(domainKeyBytesDec, 8, masterKey, 0, masterKeyLen);
 
-            var sha1 = new SHA1Managed();
+            var sha1 = new SHA1CryptoServiceProvider();
             var masterKeySha1 = sha1.ComputeHash(masterKey);
             var masterKeySha1Hex = BitConverter.ToString(masterKeySha1).Replace("-", "");
 
@@ -1947,7 +1947,7 @@ namespace SharpDPAPI
 
         private static byte[] DecryptAes256HmacSha512(byte[] shaBytes, byte[] final, byte[] encData)
         {
-            var aesCryptoProvider = new AesManaged();
+            var aesCryptoProvider = new AesCryptoServiceProvider();
 
             var ivBytes = new byte[16];
             Array.Copy(final, 32, ivBytes, 0, 16);
@@ -1965,7 +1965,7 @@ namespace SharpDPAPI
             var masterKeyFull = new byte[64];
             Array.Copy(plaintextBytes, plaintextBytes.Length - masterKeyFull.Length, masterKeyFull, 0, masterKeyFull.Length);
 
-            using (var sha1 = new SHA1Managed())
+            using (var sha1 = new SHA1CryptoServiceProvider())
             {
                 var masterKeySha1 = sha1.ComputeHash(masterKeyFull);
 
@@ -1995,7 +1995,7 @@ namespace SharpDPAPI
             var masterKeyFull = new byte[64];
             Array.Copy(plaintextBytes, plaintextBytes.Length - masterKeyFull.Length, masterKeyFull, 0, masterKeyFull.Length);
 
-            using (var sha1 = new SHA1Managed())
+            using (var sha1 = new SHA1CryptoServiceProvider())
             {
                 var masterKeySha1 = sha1.ComputeHash(masterKeyFull);
 

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -211,7 +211,7 @@ namespace SharpDPAPI
                                     bkrp.Initialize(DCIPAdress.ToString(), System.Environment.UserDomainName);
                                     var keyBytes = bkrp.BackuprKey(SharpDPAPI.Dpapi.GetDomainKey(masterKeyBytes));
                                     var guid = $"{{{Encoding.Unicode.GetString(masterKeyBytes, 12, 72)}}}";
-                                    var sha1 = new SHA1Managed();
+                                    var sha1 = new SHA1CryptoServiceProvider();
                                     var masterKeySha1 = sha1.ComputeHash(keyBytes);
                                     var masterKeySha1Hex = BitConverter.ToString(masterKeySha1).Replace("-", "");
                                     mappings.Add(guid, masterKeySha1Hex);


### PR DESCRIPTION
This solves issues on systems with 'Use FIPS compliant algorithms for encryption, hashing, and signing' enabled (fixes #28). These alternative APIs seem to be a drop-in replacement, but I have not been able to verify this in all cases.