### PR TITLE
Solve the problem of cookies files being occupied

### DIFF
--- a/SharpChrome/SharpChrome.csproj
+++ b/SharpChrome/SharpChrome.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Domain\Info.cs" />
     <Compile Include="lib\Bcrypt.cs" />
     <Compile Include="lib\Chrome.cs" />
+    <Compile Include="lib\Vsscopy.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SQLite\csharp-sqlite-src\alter_c.cs" />

--- a/SharpChrome/lib/Vsscopy.cs
+++ b/SharpChrome/lib/Vsscopy.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Management;
+
+namespace SharpChrome
+{
+    class Vsscopy
+    {
+        //Reference to https://learn.microsoft.com/zh-cn/previous-versions/windows/desktop/legacy/aa394428(v=vs.85)?redirectedfrom=MSDN
+        public static string CreateShadow(string volumePath = "C:\\")
+        {
+            string shadowCopyID = string.Empty;
+            try
+            {
+                ManagementClass shadowCopyClass = new ManagementClass(new ManagementPath("Win32_ShadowCopy"));
+                ManagementBaseObject inParams = shadowCopyClass.GetMethodParameters("Create");
+
+                inParams["Volume"] = volumePath;
+
+                ManagementBaseObject outParams = shadowCopyClass.InvokeMethod("Create", inParams, null);
+                shadowCopyID = outParams["ShadowID"].ToString();
+                return shadowCopyID;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("[X] {0}", e.InnerException.Message);
+                return null;
+            }
+        }
+
+        public static string ListShadow(string shadowCopyID)
+        {
+            string DeviceObject = string.Empty;
+            try
+            {
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher("SELECT * FROM Win32_ShadowCopy WHERE ID='" + shadowCopyID + "'");
+                ManagementObjectCollection shadowCopies = searcher.Get();
+
+                foreach (ManagementObject shadowCopy in shadowCopies)
+                {
+                    DeviceObject = shadowCopy.GetPropertyValue("DeviceObject").ToString();
+                }
+                return DeviceObject;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("[X] {0}", e.InnerException.Message);
+                return null;
+            }
+        }
+
+        public static void DeleteShadow(string ShadowID)
+        {
+            try
+            {
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher("SELECT * FROM Win32_ShadowCopy WHERE ID='" + ShadowID + "'");
+                ManagementObjectCollection shadowCopies = searcher.Get();
+
+                foreach (ManagementObject shadowCopy in shadowCopies)
+                {
+                    shadowCopy.Delete();
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("[X] {0}", e.InnerException.Message);
+            }
+        }
+    }
+}

--- a/SharpDPAPI/lib/Interop.cs
+++ b/SharpDPAPI/lib/Interop.cs
@@ -573,5 +573,8 @@ namespace SharpDPAPI
                 return "";
             }
         }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CopyFile(string lpExistingFileName, string lpNewFileName, bool bFailIfExists);
     }
 }


### PR DESCRIPTION
In the new version of Chrome, when Chrome is running, the Cookies file will be displayed as being occupied by chrome.exe and cannot be read or copied. This restriction can be bypassed using volume shadow technology, but administrator rights are required to copy.