### PR TITLE
Fix the masterkeys /hashes when running as local admin

### DIFF
--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -198,7 +198,7 @@ namespace SharpDPAPI
                                 }
                                 else if (dumpHash)
                                 {
-                                    userSID = !String.IsNullOrEmpty(userSID) ? userSID : Dpapi.ExtractSidFromPath(file);
+                                    userSID = Dpapi.ExtractSidFromPath(file);
                                     plaintextMasterKey = Dpapi.FormatHash(masterKeyBytes, userSID, isDomain ? 3 : 1);
                                 }
                                 else if(rpc && isDomain)


### PR DESCRIPTION
The current/incorrect behaviour for the `masterkeys /hashes` when running as local admin always returns the SID of the first matched users for all the hashes, including hashes of masterkeys of other users. For example, the following shows the SID for the last two masterkeys having the wrong SID `-1002`, which is valid for only the first user:

```
SharpDPAPI.exe masterkeys /hashes

  __                 _   _       _ ___
 (_  |_   _. ._ ._  | \ |_) /\  |_) |
 __) | | (_| |  |_) |_/ |  /--\ |  _|_
                |
  v1.11.3


[*] Action: User DPAPI Masterkey File Triage

[*] Will dump user masterkey hashes

[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1002\7809c<redacted>
[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1000\6b7f<redacted>
[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1000\781ffe<redacted>

[*] Preferred master keys:

C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1002:7809c<redacted>
C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1000:6b7f<redacted>


[*] User master key hashes:

{7809ce<redacted>}:$DPAPImk$2*1*S-1-5-<redacted>3762876-1002*aes256*sha512*8000*984d99<redacted>
{6b7f1<redacted>}:$DPAPImk$2*1*S-1-5-<redacted>3762876-1002*aes256*sha512*8000*736c797<redacted>
{781ff<redacted>}:$DPAPImk$2*1*S-1-5-<redacted>3762876-1002*aes256*sha512*8000*6c5fc<redacted>
```


The below, shows the result of the one with this patch:

```
SharpDPAPI.exe masterkeys /hashes

  __                 _   _       _ ___
 (_  |_   _. ._ ._  | \ |_) /\  |_) |
 __) | | (_| |  |_) |_/ |  /--\ |  _|_
                |
  v1.11.3


[*] Action: User DPAPI Masterkey File Triage

[*] Will dump user masterkey hashes

[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1002\7809c<redacted>
[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1000\6b7f<redacted>
[*] Found MasterKey : C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-<redacted>76-1000\781ffe<redacted>

[*] Preferred master keys:

C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-21-314<redacted>2876-1002:7809c<redacted>
C:\Users\<redacted>\AppData\Roaming\Microsoft\Protect\S-1-5-21-314<redacted>2876-1000:6b7f<redacted>


[*] User master key hashes:

{7809c<redacted>}:$DPAPImk$2*1*S-1-5-21-314<redacted>2876-1002*aes256*sha512*8000*984d992d<redacted>
{6b7f<redacted>}:$DPAPImk$2*1*S-1-5-21-314<redacted>2876-1000*aes256*sha512*8000*736c79718<redacted>
{781ffe<redacted>}:$DPAPImk$2*1*S-1-5-21-314<redacted>2876-1000*aes256*sha512*8000*6c5fc3b4<redacted>
```