### PR TITLE
Fixed crypto API exceptions and bypassed FIPS enforcement

### DIFF
--- a/SharpChrome/SQLite/csharp-sqlite-src/crypto.cs
+++ b/SharpChrome/SQLite/csharp-sqlite-src/crypto.cs
@@ -163,9 +163,9 @@ static void CODEC_TRACE( string T, params object[] ap ) { if ( sqlite3PagerTrace
     const int CIPHER_ENCRYPT = 1;        //#define CIPHER_ENCRYPT 1
 
 #if NET_2_0
-    static RijndaelCryptoServiceProvider Aes = new RijndaelCryptoServiceProvider();
+    static RijndaelManaged Aes = new RijndaelManaged();
 #else
-    static AesCryptoServiceProvider Aes = new AesCryptoServiceProvider();
+    static AesManaged Aes = new AesManaged();
 #endif
 
     /* BEGIN CRYPTO */

--- a/SharpDPAPI/app.config
+++ b/SharpDPAPI/app.config
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+	<startup>
+		<supportedRuntime version="v2.0.50727"/>
+	</startup>
+	<runtime>
+		<enforceFIPSPolicy enabled="false"/>
+	</runtime>
+</configuration>

--- a/SharpDPAPI/lib/Crypto.cs
+++ b/SharpDPAPI/lib/Crypto.cs
@@ -74,7 +74,7 @@ namespace SharpDPAPI
                 case 26128: // 26128 == CALG_AES_256
                 {
                     // takes a byte array of ciphertext bytes and a key array, decrypt the blob with AES256
-                    var aesCryptoProvider = new AesCryptoServiceProvider();
+                    var aesCryptoProvider = new AesManaged();
 
                     var ivBytes = new byte[16];
 
@@ -139,7 +139,7 @@ namespace SharpDPAPI
 
                 byte[] bufferI = Helpers.Combine(ipad, saltBytes);
                 
-                using (var sha1 = new SHA1CryptoServiceProvider())
+                using (var sha1 = new SHA1Managed())
                 {
                     var sha1BufferI = sha1.ComputeHash(bufferI);
                     
@@ -182,7 +182,7 @@ namespace SharpDPAPI
 
             if (algHash == 32772)
             {
-                using (var sha1 = new SHA1CryptoServiceProvider())
+                using (var sha1 = new SHA1Managed())
                 {
                     var ipadSHA1bytes = sha1.ComputeHash(ipad);
                     var ppadSHA1bytes = sha1.ComputeHash(opad);
@@ -250,7 +250,7 @@ namespace SharpDPAPI
         {
             // helper to AES decrypt a given blob with optional IV
 
-            var aesCryptoProvider = new AesCryptoServiceProvider();
+            var aesCryptoProvider = new AesManaged();
 
             aesCryptoProvider.Key = key;
             if (IV.Length != 0)

--- a/SharpDPAPI/lib/Dpapi.cs
+++ b/SharpDPAPI/lib/Dpapi.cs
@@ -1786,7 +1786,7 @@ namespace SharpDPAPI
                 {
                     // Calculate SHA1 from user password
                     byte[] sha1bytes_password;
-                    using (var sha1 = new SHA1CryptoServiceProvider())
+                    using (var sha1 = new SHA1Managed())
                     {
                         sha1bytes_password = sha1.ComputeHash(utf16pass);
                     }
@@ -1897,7 +1897,7 @@ namespace SharpDPAPI
             var masterKey = new byte[masterKeyLen];
             Buffer.BlockCopy(domainKeyBytesDec, 8, masterKey, 0, masterKeyLen);
 
-            var sha1 = new SHA1CryptoServiceProvider();
+            var sha1 = new SHA1Managed();
             var masterKeySha1 = sha1.ComputeHash(masterKey);
             var masterKeySha1Hex = BitConverter.ToString(masterKeySha1).Replace("-", "");
 
@@ -2014,7 +2014,7 @@ namespace SharpDPAPI
             var masterKeyFull = new byte[64];
             Array.Copy(plaintextBytes, plaintextBytes.Length - masterKeyFull.Length, masterKeyFull, 0, masterKeyFull.Length);
 
-            using (var sha1 = new SHA1CryptoServiceProvider())
+            using (var sha1 = new SHA1Managed())
             {
                 var masterKeySha1 = sha1.ComputeHash(masterKeyFull);
 
@@ -2044,7 +2044,7 @@ namespace SharpDPAPI
             var masterKeyFull = new byte[64];
             Array.Copy(plaintextBytes, plaintextBytes.Length - masterKeyFull.Length, masterKeyFull, 0, masterKeyFull.Length);
 
-            using (var sha1 = new SHA1CryptoServiceProvider())
+            using (var sha1 = new SHA1Managed())
             {
                 var masterKeySha1 = sha1.ComputeHash(masterKeyFull);
 

--- a/SharpDPAPI/lib/Triage.cs
+++ b/SharpDPAPI/lib/Triage.cs
@@ -211,7 +211,7 @@ namespace SharpDPAPI
                                     bkrp.Initialize(DCIPAdress.ToString(), System.Environment.UserDomainName);
                                     var keyBytes = bkrp.BackuprKey(SharpDPAPI.Dpapi.GetDomainKey(masterKeyBytes));
                                     var guid = $"{{{Encoding.Unicode.GetString(masterKeyBytes, 12, 72)}}}";
-                                    var sha1 = new SHA1CryptoServiceProvider();
+                                    var sha1 = new SHA1Managed();
                                     var masterKeySha1 = sha1.ComputeHash(keyBytes);
                                     var masterKeySha1Hex = BitConverter.ToString(masterKeySha1).Replace("-", "");
                                     mappings.Add(guid, masterKeySha1Hex);


### PR DESCRIPTION
This PR fixes #28 and #33.

PR #29 broke some crypto functionality by using the `*CryptoServiceProvider` APIs.

The initial exception reported in #33 shows that an IV is expected because the overloaded function was expected. Explicitly passing the IV resolved that exception. After further testing, despite the `*Managed` and `*CryptoServiceProvider` APIs supposedly being interchangeable, something is breaking internally, which I could not resolve.

The reason for this change, as mentioned in PR #29, was to use FIPS-compliant algorithms on hosts that enforce FIPS. The `*CryptoServiceProvider` APIs are "somewhat"  FIPS-compliant so, in theory, this is could work. However, these APIs broke functionality.

The other option is to disable the enforcement of FIPS in the application's config file: `app.config`.

This PR revers back to the `*Managed` APIs and disables enforcement of FIPS.