### PR TITLE
Chrome State Key Parsing Bugfix

### DIFF
--- a/SharpChrome/lib/Chrome.cs
+++ b/SharpChrome/lib/Chrome.cs
@@ -780,15 +780,26 @@ namespace SharpChrome
         public static string GetBase64EncryptedKey(string localStatePath)
         {
             // extracts the base64 encoded encrypted chrome AES state key
+            // quote-wrap the search term in order to handle multiple
+            // JSON keys with "encrypted_key" (e.g., "app_bound_encrypted_key")
             string localStateData = File.ReadAllText(localStatePath);
-            string searchTerm = "encrypted_key";
-
+            string searchTerm = "\"encrypted_key\"";
+            int indexPadding = 2;
             int startIndex = localStateData.IndexOf(searchTerm);
+
+            // if we can't find the quote-wrapped variant, fall back to
+            // the original variant
+            if (startIndex < 0)
+            {
+                searchTerm = "encrypted_key";
+                indexPadding = 3;
+                startIndex = localStateData.IndexOf(searchTerm);
+            }
 
             if (startIndex < 0)
                 return "";
 
-            int keyIndex = startIndex + searchTerm.Length + 3;
+            int keyIndex = startIndex + searchTerm.Length + indexPadding;
             string tempVals = localStateData.Substring(keyIndex);
 
             int stopIndex = tempVals.IndexOf('"');


### PR DESCRIPTION
This is a very minor bugfix to address how the statekeys are pulled from later versions of Chrome's local state file. The bug is a result of parsing the JSON file via an `indexOf()` against the `encrypted_key` substring. Many versions of Chrome I tested have two JSON keys with `encrypted_key` in the name. When the `app_bound_encrypted_key` JSON key comes before the `encrypted_key` key within the file, SharpChrome pulls the former and attempts to decrypt it as a state key.

![image](https://github.com/GhostPack/SharpDPAPI/assets/135625870/a27b4194-4fd4-4216-8da2-43a527cfa799)

This will cause SharpChrome to fail with the following error message:

```
[X] AES state key has unknown/non-DPAPI encoding.
```

The simple fix is to update the search term to be quote-wrapped, ensuring a perfect match on the expected key. Ideally, we would use JSON/Lync to parse this file, but I'm not sure if this introduces unwanted behavior under different conditions. In order to prevent this change from affecting other environments, the `Chrome.GetBase64EncryptedKey()` function will search for the quote-wrapped search term and if it fails to find the value, will fall back to the original non-quote-wrapped search term.